### PR TITLE
Removed obsolete entry - NPM socks

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,6 @@ How it looks | How to get?
 
 ## Misc :gift:
 
-### :information_source: NPM - Socks!
-
-How it looks | How to get?
--------------|---------
-<img src="https://cdn-images-1.medium.com/max/1000/0*LiRr7IR_2s1Ya7BD.jpg" width="600"> | Help fix a bug or improve documentation.  [**Take me there!**](https://medium.com/npm-inc/npm-weekly-131-get-socks-for-docs-welcome-lorin-terri-plus-global-diversity-cfp-day-is-1b965ebc19ca)
-
 
 ### :information_source: CircleCI - T-shirt + Stickers + Pin!
 


### PR DESCRIPTION
The given [link](https://medium.com/npm-inc/npm-weekly-131-get-socks-for-docs-welcome-lorin-terri-plus-global-diversity-cfp-day-is-1b965ebc19ca) contains another [link](https://npmjs.us9.list-manage.com/track/click?u=077dfd41302a71310cef619e5&id=92e492b5d7&e=aafe3dd2e0) that is broken.

![BrokenLink](https://i.imgur.com/ujVDVCE.png)

Hence have removed the obsolete NPM socks entry.